### PR TITLE
add Module::Install as a prereq

### DIFF
--- a/Meta
+++ b/Meta
@@ -24,6 +24,7 @@ devel:
 requires:
   perl: 5.8.1
   Digest::SHA1: 2.13
+  Module::Install: 0
 
 =zild:
   include_testbase: true


### PR DESCRIPTION
This should in theory fix #1, it does update the generated `dist.ini` file, however, I wasn't able to `make dist` successfully:

```
twin% make dist
rm -fr cpan .build Module-Compile-0.34.tar.gz Module-Compile-0.34
***** Creating the `cpan/` directory
zild-make-cpan
+ add-standard-files
+ cp Changes cpan
+ '[' -e Contributing ']'
+ cp Contributing cpan/CONTRIBUTING
+ '[' -e bin ']'
+ '[' -e eg ']'
+ cp -r lib cpan
+ '[' -e share ']'
+ add-test
+ '[' -d test ']'
+ cp -r test cpan/t
+ '[' -d cpan/t/extra ']'
+ '[' -d cpan/t/devel ']'
+ rm -fr cpan/t/misc cpan/t/fail
+ add-test-000
++ /home/ollisg/perl5/perlbrew/perls/perl-5.20.0/bin/perl -S zild meta =zild/test-000
+ '[' '' == require ']'
++ /home/ollisg/perl5/perlbrew/perls/perl-5.20.0/bin/perl -S zild meta =zild/test-000
+ '[' '' == none ']'
+ /home/ollisg/perl5/perlbrew/perls/perl-5.20.0/bin/perl -S zild-render-template test/000-compile-modules.t cpan/t/000-compile-modules.t
+ add-dist-ini
+ /home/ollisg/perl5/perlbrew/perls/perl-5.20.0/bin/perl -S zild-render-template dist.ini cpan/dist.ini
+ swim --to=pod --meta=Meta --pod-cpan doc/Module/Compile.swim
+ swim --to=pod --meta=Meta --pod-cpan doc/Module/Compile/Opt.swim
+ swim --to=pod --meta=Meta --pod-cpan doc/Module/Compile/Optimize.swim
***** Creating new dist: Module-Compile-0.34.tar.gz
(cd cpan; dzil build)
[DZ] beginning to build Module-Compile
Test::Base repo missing or not in right state at /home/ollisg/.perlbrew/libs/perl-5.20.0@dev/lib/perl5/Dist/Zilla/Plugin/TestBaseIncluder.pm line 47.
make: *** [dist] Error 2
twin% which_pm Test::Base
Test::Base           0.88       /home/ollisg/.perlbrew/libs/perl-5.20.0@dev/lib/perl5/Test/Base.pm
```
