### PR TITLE
fix tests on windows

### DIFF
--- a/test/data1.t
+++ b/test/data1.t
@@ -16,10 +16,12 @@ use DataTest;
 
 ok((-e $pmc), ".pmc exists");
 
-local $/;
-my $data = <DataTest::DATA>;
-is $data, "\none\ntwo\n\nthree\n\n",
-    "DATA section is correct";
+{
+    local $/;
+    my $data = <DataTest::DATA>;
+    is $data, "\none\ntwo\n\nthree\n\n",
+        "DATA section is correct";
+}
 
 my ($out, $err, $exit) = capture {
   my $app = App::Prove->new;


### PR DESCRIPTION
Apparently `App::Prove`/`TAP::Harness` breaks on Windows when `$/` is undefined and complains about "no plan".

Example failure from CPAN Testers: http://www.cpantesters.org/cpan/report/fb370a83-6bfe-1014-88cb-eaa88038f308